### PR TITLE
Add support for multiple monitors

### DIFF
--- a/.subtrees/gaze-ocr/gaze_ocr/_gaze_ocr.py
+++ b/.subtrees/gaze-ocr/gaze_ocr/_gaze_ocr.py
@@ -69,8 +69,17 @@ class CursorLocation:
                 self.keyboard.right(1)
 
 
+class EyeTrackerFallback(Enum):
+    MAIN_SCREEN = auto()
+    ACTIVE_WINDOW = auto()
+
+
 class OcrCache:
-    def __init__(self, ocr_reader: Reader, fallback_when_no_eye_tracker: str = "main_screen"):
+    def __init__(
+        self,
+        ocr_reader: Reader,
+        fallback_when_no_eye_tracker: EyeTrackerFallback = EyeTrackerFallback.MAIN_SCREEN,
+    ):
         self.ocr_reader = ocr_reader
         self._last_time_range = None
         self._last_screen_contents = None
@@ -97,7 +106,10 @@ class OcrCache:
             if bounding_box:
                 self._last_screen_contents = self.ocr_reader.read_screen(bounding_box)
             else:
-                if self.fallback_when_no_eye_tracker == "active_window":
+                if (
+                    self.fallback_when_no_eye_tracker
+                    == EyeTrackerFallback.ACTIVE_WINDOW
+                ):
                     self._last_screen_contents = self.ocr_reader.read_current_window()
                 else:
                     self._last_screen_contents = self.ocr_reader.read_screen()
@@ -126,7 +138,7 @@ class Controller:
         app_actions=None,
         save_data_directory: Optional[str] = None,
         gaze_box_padding: int = 100,
-        fallback_when_no_eye_tracker: str = "main_screen"
+        fallback_when_no_eye_tracker: EyeTrackerFallback = EyeTrackerFallback.MAIN_SCREEN,
     ):
         self.ocr_reader = ocr_reader
         self.eye_tracker = eye_tracker
@@ -138,7 +150,9 @@ class Controller:
         self._change_radius = 10
         self._executor = futures.ThreadPoolExecutor(max_workers=1)
         self._future = None
-        self._ocr_cache = OcrCache(ocr_reader, fallback_when_no_eye_tracker=fallback_when_no_eye_tracker)
+        self._ocr_cache = OcrCache(
+            ocr_reader, fallback_when_no_eye_tracker=fallback_when_no_eye_tracker
+        )
         self.fallback_when_no_eye_tracker = fallback_when_no_eye_tracker
 
     def shutdown(self, wait=True):
@@ -210,7 +224,10 @@ class Controller:
             if gaze_point:
                 self._future.set_result(self.ocr_reader.read_nearby(gaze_point))
             else:
-                if self.fallback_when_no_eye_tracker == "active_window":
+                if (
+                    self.fallback_when_no_eye_tracker
+                    == EyeTrackerFallback.ACTIVE_WINDOW
+                ):
                     self._future.set_result(self.ocr_reader.read_current_window())
                 else:
                     self._future.set_result(self.ocr_reader.read_screen())

--- a/.subtrees/screen-ocr/screen_ocr/_screen_ocr.py
+++ b/.subtrees/screen-ocr/screen_ocr/_screen_ocr.py
@@ -247,19 +247,18 @@ class Reader:
         )
 
     def read_current_window(self):
-        if self._is_talon_backend():
-            assert ui
-            win = ui.active_window()
-            bounding_box = to_bounding_box(win.rect)
-            screenshot, bounding_box = self._clean_screenshot(
-                bounding_box, clamp_to_main_screen=False
-            )
-            return self.read_image(
-                screenshot,
-                bounding_box=bounding_box,
-            )
-        else:
+        if not self._is_talon_backend():
             raise NotImplementedError
+        assert ui
+        win = ui.active_window()
+        bounding_box = to_bounding_box(win.rect)
+        screenshot, bounding_box = self._clean_screenshot(
+            bounding_box, clamp_to_main_screen=False
+        )
+        return self.read_image(
+            screenshot,
+            bounding_box=bounding_box,
+        )
 
     def read_image(
         self,

--- a/gaze_ocr_talon.py
+++ b/gaze_ocr_talon.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from math import floor
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Sequence
+from typing import Dict, Iterable, Literal, Optional, Sequence
 
 import numpy as np
 from talon import Context, Module, actions, app, cron, fs, screen, settings
@@ -109,16 +109,9 @@ mod.setting(
 )
 mod.setting(
     "ocr_behavior_when_no_eye_tracker",
-    type=gaze_ocr.EyeTrackerFallback,
-    default=gaze_ocr.EyeTrackerFallback.MAIN_SCREEN,
+    type=Literal["MAIN_SCREEN", "ACTIVE_WINDOW"],
+    default="MAIN_SCREEN",
     desc="Behavior when no data from the eye tracker",
-)
-
-mod.setting(
-    "ocr_clamp_to_main_screen",
-    type=bool,
-    default=False,
-    desc="Should searches clamp to the main screen",
 )
 
 mod.mode("gaze_ocr_disambiguation")
@@ -264,7 +257,6 @@ def reload_backend(name, flags):
             backend="talon",
             radius=settings.get("user.ocr_gaze_point_padding"),
             homophones=homophones,
-            clamp_to_main_screen=settings.get("user.ocr_clamp_to_main_screen"),
         )
     else:
         if setting_ocr_use_talon_backend and not ocr:
@@ -272,7 +264,6 @@ def reload_backend(name, flags):
         ocr_reader = screen_ocr.Reader.create_fast_reader(
             radius=settings.get("user.ocr_gaze_point_padding"),
             homophones=homophones,
-            clamp_to_main_screen=settings.get("user.ocr_clamp_to_main_screen"),
         )
     gaze_ocr_controller = gaze_ocr.Controller(
         ocr_reader,
@@ -282,9 +273,9 @@ def reload_backend(name, flags):
         app_actions=gaze_ocr.talon.AppActions(),
         save_data_directory=settings.get("user.ocr_logging_dir"),
         gaze_box_padding=settings.get("user.ocr_gaze_box_padding"),
-        fallback_when_no_eye_tracker=settings.get(
-            "user.ocr_behavior_when_no_eye_tracker"
-        ),
+        fallback_when_no_eye_tracker=gaze_ocr.EyeTrackerFallback[
+            settings.get("user.ocr_behavior_when_no_eye_tracker")
+        ],
     )
 
 

--- a/gaze_ocr_talon.py
+++ b/gaze_ocr_talon.py
@@ -111,7 +111,7 @@ mod.setting(
     "ocr_behavior_when_no_eye_tracker",
     type=Literal["MAIN_SCREEN", "ACTIVE_WINDOW"],
     default="MAIN_SCREEN",
-    desc="Behavior when no data from the eye tracker",
+    desc="Region to OCR when no data from the eye tracker",
 )
 
 mod.mode("gaze_ocr_disambiguation")
@@ -274,7 +274,7 @@ def reload_backend(name, flags):
         save_data_directory=settings.get("user.ocr_logging_dir"),
         gaze_box_padding=settings.get("user.ocr_gaze_box_padding"),
         fallback_when_no_eye_tracker=gaze_ocr.EyeTrackerFallback[
-            settings.get("user.ocr_behavior_when_no_eye_tracker")
+            settings.get("user.ocr_behavior_when_no_eye_tracker").upper()
         ],
     )
 

--- a/gaze_ocr_talon.py
+++ b/gaze_ocr_talon.py
@@ -109,9 +109,9 @@ mod.setting(
 )
 mod.setting(
     "ocr_behavior_when_no_eye_tracker",
-    type=str,
-    default="active_window",
-    desc="Behavior when no data from the eye tracker, 'active_window' or 'main_screen'",
+    type=gaze_ocr.EyeTrackerFallback,
+    default=gaze_ocr.EyeTrackerFallback.MAIN_SCREEN,
+    desc="Behavior when no data from the eye tracker",
 )
 
 mod.setting(
@@ -264,7 +264,7 @@ def reload_backend(name, flags):
             backend="talon",
             radius=settings.get("user.ocr_gaze_point_padding"),
             homophones=homophones,
-            clamp_to_main_screen=settings.get("user.ocr_clamp_to_main_screen")
+            clamp_to_main_screen=settings.get("user.ocr_clamp_to_main_screen"),
         )
     else:
         if setting_ocr_use_talon_backend and not ocr:
@@ -282,7 +282,9 @@ def reload_backend(name, flags):
         app_actions=gaze_ocr.talon.AppActions(),
         save_data_directory=settings.get("user.ocr_logging_dir"),
         gaze_box_padding=settings.get("user.ocr_gaze_box_padding"),
-        fallback_when_no_eye_tracker=settings.get("user.ocr_behavior_when_no_eye_tracker")
+        fallback_when_no_eye_tracker=settings.get(
+            "user.ocr_behavior_when_no_eye_tracker"
+        ),
     )
 
 
@@ -765,9 +767,7 @@ class GazeOcrActions:
             # Show bounding box.
             c.paint.style = c.paint.Style.STROKE
             c.paint.color = debug_color
-            c.draw_rect(
-                contents_rect
-            )
+            c.draw_rect(contents_rect)
             if contents.screen_coordinates:
                 c.paint.style = c.paint.Style.STROKE
                 c.paint.color = debug_color
@@ -816,7 +816,7 @@ class GazeOcrActions:
         canvas_rect.height += 100
         canvas_rect.width += 100
         canvas_rect.center = center
-      
+
         debug_canvas = Canvas.from_rect(canvas_rect)
         debug_canvas.register("draw", on_draw)
         debug_canvas.freeze()


### PR DESCRIPTION
This is activated with two main talon settings, controlling if clamping occurs and the behaviour when there is no eye tracker data.

Addresses #29 & #30 , although there could be more options in terms of when to use different monitors

Only implemented for talon backend at the moment. Added to_rect and to_bounding box helper functions. It isn't the cleanest but wasn't sure the best way of handling the multiple backends and so left it a little messy as an initial commit but could be refactored.

